### PR TITLE
tiny typo correction

### DIFF
--- a/src/pages/en/integrations/php.mdx
+++ b/src/pages/en/integrations/php.mdx
@@ -115,7 +115,7 @@ override some components of Treblle.
 
 The following values are supported:
 
-- `client` - an instance of Guzzle client configured to behive as you want (e.g. controling the timeout or other
+- `client` - an instance of Guzzle client configured to behave as you want (e.g. controling the timeout or other
   aspects)
 - `url` - Treblle API endpoint URL you want to use
 


### PR DESCRIPTION
This corrects a tiny Typo in the documentation for the PHP Integration, where `behave` is spelled `behive`.  noticed whilst reading through the docs.