### PR TITLE
fix: typo error

### DIFF
--- a/src/pages/en/integrations/django.mdx
+++ b/src/pages/en/integrations/django.mdx
@@ -36,7 +36,7 @@ MIDDLEWARE_CLASSES = [
 
 ## Getting started
 
-Next, create a FREE account on [Treblle](https://treblle.com) to get an API key and Project ID. After you have those simply initialize Treblle in your **settinsg.py** file like so for django:
+Next, create a FREE account on [Treblle](https://treblle.com) to get an API key and Project ID. After you have those simply initialize Treblle in your **settings.py** file like so for django:
 
 ```py
 TREBLLE_INFO = {


### PR DESCRIPTION
This fixes #10 

I corrected a misspelling 

Previous:
> **settinsg.py**

Now:
> **settings.py**