### PR TITLE
Fix grammmatical error on line 37

### DIFF
--- a/src/pages/en/sdk-development.md
+++ b/src/pages/en/sdk-development.md
@@ -34,7 +34,7 @@ The last piece of logic your SDK needs to do is send the payload to Treblle. Thi
 - https://punisher.treblle.com
 - https://sicario.treblle.com
 
-You can randomly pick one of the mentioned endpoints to send the payload to. Here is an implementation in JavaScript which randomly picks and endpoint to send the payload to. This act as a sort of ad hoc load balancing strategy implemented within the SDK itself.
+You can randomly pick one of the mentioned endpoints to send the payload to. Here is an implementation in JavaScript which randomly picks an endpoint to send the payload to. This act as a sort of ad hoc load balancing strategy implemented within the SDK itself.
 
 ```js
 function getTreblleEndpoint() {


### PR DESCRIPTION
## Description

This PR addresses a grammatical issue in the text where "and" was incorrectly used instead of "an" in the second sentence on line 37. The correction ensures proper grammar and clarity.

## Motivation and Context

The motivation behind this change is to enhance the readability and correctness of the text. The incorrect use of "and" created a grammatical error that needed correction for better comprehension.

## Changes Made

- Replaced "and" with "an" in the second sentence on line 37 to correct the grammatical error.

## Testing

No testing is required for this change, as it involves a straightforward grammatical correction with no impact on functionality.

## Checklist

- [x] Code compiles without errors or warnings
- [x] Code follows the project's coding standards and style guidelines
- [ ] Unit tests pass successfully (Not applicable to this change)
- [ ] Documentation (if applicable) has been updated to reflect the changes (Not applicable to this change)
- [x] Reviewed my own code for logical errors and issues
- [ ] Sought input from colleagues or team members (Not applicable to this change)

## Related Issues

None

## Additional Information

No additional information to add.